### PR TITLE
Update Data Carpentry URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ dc_blog        : "http://www.datacarpentry.org/blog/"
 dc_contact     : "info@datacarpentry.org"
 dc_github      : "https://github.com/datacarpentry"
 dc_githubio    : "http://datacarpentry.github.io/"
-dc_site        : "http://data-carpentry.org"
+dc_site        : "http://www.datacarpentry.org"
 dc_twitter     : "http://twitter.com/datacarpentry"
 #--------------------------------------------------------------------------------
 # Settings for Jekyll - should not need to be modified.


### PR DESCRIPTION
Data Carpentry have a new URL. This fixes the broken Lessons link on the index page due to a problem with redirections from http://data-carpentry.org/lessons.

Broken URL redirections have been reported to Data Carpentry via email.
